### PR TITLE
Absinthe unsubscribe request and reply

### DIFF
--- a/gql/transport/phoenix_channel_websockets.py
+++ b/gql/transport/phoenix_channel_websockets.py
@@ -229,6 +229,9 @@ class PhoenixChannelWebsocketsTransport(WebsocketsTransport):
 
                 status = str(payload.get("status"))
 
+                # Unsubscription reply?
+                unsubscribe_listener_id = self.unsubscribe_answer_ids.pop(answer_id, None)
+
                 if status == "ok":
 
                     answer_type = "reply"
@@ -236,14 +239,12 @@ class PhoenixChannelWebsocketsTransport(WebsocketsTransport):
 
                     if isinstance(response, dict) and "subscriptionId" in response:
                         subscription_id = str(response.get("subscriptionId"))
-                        if answer_id in self.unsubscribe_answer_ids:
-                            # Unsubscription reply
-                            listener_query_id = self.unsubscribe_answer_ids[answer_id]
-                            del self.unsubscribe_answer_ids[answer_id]
+                        if unsubscribe_listener_id is not None:
+
                             answer_type = "complete"
 
-                            if self.subscription_ids_to_query_ids.get(subscription_id) != listener_query_id:
-                                raise ValueError(f"Listener {listener_query_id} referenced in unsubscribe reply does not exist")
+                            if self.subscription_ids_to_query_ids.get(subscription_id) != unsubscribe_listener_id:
+                                raise ValueError(f"Listener {unsubscribe_listener_id} referenced in unsubscribe reply does not exist")
                         else:
                             # Subscription reply
                             self.subscription_ids_to_query_ids[subscription_id] = answer_id

--- a/gql/transport/phoenix_channel_websockets.py
+++ b/gql/transport/phoenix_channel_websockets.py
@@ -241,6 +241,7 @@ class PhoenixChannelWebsocketsTransport(WebsocketsTransport):
                         subscription_id = str(response.get("subscriptionId"))
                         if unsubscribe_listener_id is not None:
 
+                            answer_id = unsubscribe_listener_id
                             answer_type = "complete"
 
                             if self.subscription_ids_to_query_ids.get(subscription_id) != unsubscribe_listener_id:


### PR DESCRIPTION
Sends an "unsubscribe" Phoenix Channel message to Absinthe in `_send_stop_message`, and parses the reply to an unsubscribe request as a "complete" answer type in `_parse_answer.` The unsubscribe request's query_id and its corresponding "listener" query_id are saved in a dictionary attribute.

Tested on Python 3.8.10 with a live Absinthe 1.6 development server.
